### PR TITLE
modified extract script for bash version compatibility

### DIFF
--- a/scripts/hdImgsExtractor.sh
+++ b/scripts/hdImgsExtractor.sh
@@ -13,7 +13,7 @@ outputFolderName=hdImgs
 camIdx=-1;
 for p in 0
 	do
-	for c in {0..30}
+	for c in $(seq 0 30)
 		do
 		videoFileName=$(printf "$inputFolderName/hd_%02d_%02d.mp4" $p $c)
 		outputvideoFileName=$(printf "$outputFolderName/%02d_%02d" $p $c)

--- a/scripts/kinectImgsExtractor.sh
+++ b/scripts/kinectImgsExtractor.sh
@@ -12,7 +12,7 @@ outputFolderName=kinectImgs
 camIdx=-1;
 for p in 50
 	do
-	for c in {1..10}
+	for c in $(seq 1 10)
 		do
 		videoFileName=$(printf "$inputFolderName/kinect_%02d_%02d.mp4" $p $c)
 		outputvideoFileName=$(printf "$outputFolderName/%02d_%02d" $p $c)

--- a/scripts/vgaImgsExtractor.sh
+++ b/scripts/vgaImgsExtractor.sh
@@ -11,9 +11,10 @@ fmt=${1-jpg}
 inputFolderName=vgaVideos
 outputFolderName=vgaImgs
 
-for p in {1..20}
+# older version bash compatibility, for version greater than 4.1, it can be for p in {1..20}
+for p in $(seq 1 20)
 	do
-	for c in {1..24}
+	for c in $(seq 1 24)
 		do
 		videoFileName=$(printf "$inputFolderName/vga_%02d_%02d.mp4" $p $c)
 		outputvideoFileName=$(printf "$outputFolderName/%02d_%02d" $p $c)


### PR DESCRIPTION
modified extract script for bash version compatibility
In sequence loop, older version only supports for x in $(seq a b). 